### PR TITLE
Criação do tema corporativo

### DIFF
--- a/cc-corporativo/cc-corporativo-colors.scss
+++ b/cc-corporativo/cc-corporativo-colors.scss
@@ -1,0 +1,69 @@
+$cc-warn: mat-palette($mat-red, 800);
+
+$cc-mat-teal: (
+        50: #E0F2F1,
+        100: #B2DFDB,
+        200: #80CBC4,
+        300: #4DB6AC,
+        400: #26A69A,
+        500: #009688,
+        600: #00897B,
+        700: #00796B,
+        800: #00695C,
+        900: #004D40,
+        A100: #A7FFEB,
+        A200: #64FFDA,
+        A400: #1DE9B6,
+        A700: #00BFA5,
+        contrast: (
+                50: $dark-primary-text,
+                100: $dark-primary-text,
+                200: $dark-primary-text,
+                300: $dark-primary-text,
+                400: $dark-primary-text,
+                500: $dark-primary-text,
+                600: $light-primary-text,
+                700: $light-primary-text,
+                800: $light-primary-text,
+                900: $light-primary-text,
+                A100: $dark-primary-text,
+                A200: $dark-primary-text,
+                A400: $dark-primary-text,
+                A700: $light-primary-text
+        )
+);
+$cc-primary: mat-palette($cc-mat-teal, 800);
+
+$cc-mat-orange: (
+        50: #FFF3E0,
+        100: #FFE0B2,
+        200: #FFCC80,
+        300: #FFB74D,
+        400: #FFA726,
+        500: #FF9800,
+        600: #FB8C00,
+        700: #F57C00,
+        800: #EF6C00,
+        900: #E65100,
+        A100: #FFD180,
+        A200: #FFAB40,
+        A400: #FF9100,
+        A700: #FF6D00,
+        contrast: (
+                50: mat-color($cc-primary),
+                100: mat-color($cc-primary),
+                200: mat-color($cc-primary),
+                300: mat-color($cc-primary),
+                400: mat-color($cc-primary),
+                500: mat-color($cc-primary),
+                600: mat-color(mat-palette($cc-primary, 50)),
+                700: mat-color(mat-palette($cc-primary, 50)),
+                800: mat-color(mat-palette($cc-primary, 50)),
+                900: mat-color(mat-palette($cc-primary, 50)),
+                A100: mat-color($cc-primary),
+                A200: mat-color($cc-primary),
+                A400: mat-color($cc-primary),
+                A700: mat-color($cc-primary)
+        )
+);
+$cc-accent: mat-palette($cc-mat-orange, 600);

--- a/cc-corporativo/cc-corporativo.scss
+++ b/cc-corporativo/cc-corporativo.scss
@@ -1,0 +1,8 @@
+@import "~@angular/material/theming";
+@import "cc-corporativo-colors";
+
+@include mat-core();
+
+$cc-theme: mat-light-theme($cc-primary, $cc-accent, $cc-warn);
+
+@include angular-material-theme($cc-theme);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@govce/cc-material-themes",
   "version": "0.0.2",
-  "private": false
+  "private": false,
+  "devDependencies": {
+    "@angular/material": "^6.2.0"
+  }
 }


### PR DESCRIPTION
Criação de tema corporativo com base nas paleta primary mat-palette($mat-teal, 800) e  accent mat-palette($mat-orange, 600), alterando base de contraste e warn mat-palette($mat-red, 800)